### PR TITLE
Clarify useOrderEntry doc and its dependency on useOrderbookStream

### DIFF
--- a/apps/docs/pages/docs/hooks/orders.mdx
+++ b/apps/docs/pages/docs/hooks/orders.mdx
@@ -15,6 +15,8 @@ export interface OrderEntryReturn {
   maxQty: number;
   freeCollateral: number;
   markPrice: number;
+  estLiqPrice?: number | null;
+  estLeverage?: number | null;
 
   symbolConfig: API.SymbolExt;
   helper: {
@@ -37,6 +39,9 @@ const useOrderEntry = (
 - `maxQty`: The maximum quantity that the user can trade based on the free collateral.
 - `freeCollateral`: The amount collateral available for trading, factoring in open positions and pending orders.
 - `markPrice`: The mark price of the symbol.
+- `estLiqPrice`: The estimated liquidation price based on the chosen order type and the orderbook bid and ask prices. 
+
+> Note: Calculating `estLiqPrice` requires the `watchOrderbook` option to be set to `true`. It also depends on the `orderbook:update` event emitted by the `useOrderbookStream` hook, which must be used elsewhere in your application.
 
 ### Data calculations
 


### PR DESCRIPTION
- Emphasized the dependency between `useOrderEntry` and `useOrderbookStream` hooks for the `orderbook:update` event to [emit](https://github.com/OrderlyNetwork/js-sdk/blob/21c02ffbc8cd154f816b0835cd853639a68fcd5f/packages/hooks/src/orderly/useOrderbookStream.ts#L372) and update the [`askAndBid`](https://github.com/OrderlyNetwork/js-sdk/blob/21c02ffbc8cd154f816b0835cd853639a68fcd5f/packages/hooks/src/orderly/useOrderEntry.ts#L593) in useOrderEntry hook
- Highlighted the requirement for the `watchOrderbook` option
