### PR TITLE
feat: more robust createOrderlyKey

### DIFF
--- a/packages/core/src/helper.ts
+++ b/packages/core/src/helper.ts
@@ -86,6 +86,7 @@ export function generateAddOrderlyKeyMessage(inputs: {
   primaryType: keyof typeof definedTypes;
   expiration?: number;
   timestamp?: number;
+  scope?: string;
 }) {
   const {
     publicKey,
@@ -94,13 +95,14 @@ export function generateAddOrderlyKeyMessage(inputs: {
     brokerId,
     expiration = 365,
     timestamp = Date.now(),
+    scope = "read,trading",
   } = inputs;
   // const now = Date.now();
   // message;
   const message = {
     brokerId,
     orderlyKey: publicKey,
-    scope: "read,trading",
+    scope,
     chainId,
     timestamp,
     expiration: timestamp + 1000 * 60 * 60 * 24 * expiration,

--- a/packages/hooks/src/useAccount.ts
+++ b/packages/hooks/src/useAccount.ts
@@ -56,8 +56,16 @@ export const useAccount = () => {
   // );
 
   const createOrderlyKey = useCallback(
-    async (remember: boolean) => {
-      return account.createOrderlyKey(remember ? 365 : 30);
+    async (
+      remember: boolean,
+      scope?: string,
+      shouldMutateAppState: boolean = true
+    ) => {
+      return account.createOrderlyKey(
+        remember ? 365 : 30,
+        scope,
+        shouldMutateAppState
+      );
     },
     [account]
   );


### PR DESCRIPTION
Would be nice if the createOrderlyKey function provided by the useAccount hook can expose expiration and scope as parameters. Currently the scope is hardcoded to “trading,read”

also in case I am generating multiple keys and don't want to touch the keystore and mutate state
we can make the mutation of the state and storage optional (return just the key results)
